### PR TITLE
Added unique identification to headers, to allow address and click from code

### DIFF
--- a/js/liteaccordion.jquery.js
+++ b/js/liteaccordion.jquery.js
@@ -30,7 +30,9 @@
 
 			theme : 'basic', // basic, light*, dark, stitch*
 			rounded : false,
-			enumerateSlides : false
+			enumerateSlides : false,
+
+			uniqueName : ''
 		},
 		
 		// merge defaults with options in new settings object				
@@ -109,6 +111,8 @@
 				.next()
 					.width(slideWidth)
 					.css({ left : left, paddingLeft : settings.headerWidth });
+
+			$this.addClass(settings.uniqueName + "Header" + index);
 			
 			// add number to bottom of tab
 			settings.enumerateSlides && $this.append('<b>' + (index + 1) + '</b>');			


### PR DESCRIPTION
It allows you to link and show slide you choose.
Using:  $(".{uniqueName}Header{index}").click();

Example: $(".MainSliderHeader1").click(); 
(where uniqueName: "MainSlider", and whole accordion has at least 2 slides, and currently active is first one ".MainSliderHeader0")

If you won't set uniqueName, you can work with more accordions at once or you know, there won't be more than one accordion on page.

It uses class and not id attribute, because you could want to set your own ID's to headers
It is useful, because you can from now easily create code for buttons/links automatically, as you know rules of naming algorithm.

I hope you'll find it useful, and i won't blame you for using my idea and creating your own implementation

p.s.: sorry for my language clumsiness
Marek
